### PR TITLE
feat(roles): 35 - add roles to the user and claims

### DIFF
--- a/firebase/functions/main.py
+++ b/firebase/functions/main.py
@@ -1,7 +1,8 @@
 from firebase_functions import https_fn
-from firebase_admin import initialize_app, messaging, auth, storage
+from firebase_admin import initialize_app
 
 from src.functions.send_notification import send_notification
+from src.functions.set_user_roles import set_user_roles
 
 initialize_app()
 

--- a/firebase/functions/src/functions/set_user_roles.py
+++ b/firebase/functions/src/functions/set_user_roles.py
@@ -1,0 +1,84 @@
+from firebase_functions import https_fn
+from firebase_admin import auth
+from google.cloud import firestore
+
+
+@https_fn.on_request()
+def set_user_roles(req: https_fn.Request) -> https_fn.Response:
+    """
+    This function update user roles in Firebase Authentication and Firestore.
+    It combines roles from the claims and ensures data consistency between Firestore.
+
+    **Example cURL Command**:
+
+    Emulator
+
+    ```
+    curl -X POST http://127.0.0.1:5001/<project-name>/<region>/set_user_roles \
+    -H "Content-Type: application/json" \
+    -d '{
+        "id": "<user-id>",
+        "roles": {"admin": true}
+    }'
+    ```
+
+    Firebase
+
+    ```
+    curl -X https://<region>-<project-name>.cloudfunctions.net/<project-name>/<region>/set_user_roles \
+    -H "Content-Type: application/json" \
+    -d '{
+        "id": "<user-id>",
+        "roles": {"admin": true}
+    }'
+    ```
+    """
+    try:
+        data = req.get_json()
+
+        id = data.get("id")
+        new_roles = data.get("roles")
+
+        if not id or not new_roles:
+            return https_fn.Response(
+                "Missing 'id' or 'roles' in the request payload.",
+                status=400,
+            )
+
+        user = auth.get_user(id)
+        current_claims = user.custom_claims or {}
+        current_roles = current_claims.get("roles", {})
+
+        merged_roles = {**current_roles, **new_roles}
+
+        updated_claims = {**current_claims, "roles": merged_roles}
+        auth.set_custom_user_claims(id, updated_claims)
+
+        try:
+            db = firestore.Client()
+            user_doc_ref = db.collection("users").document(id)
+            user_doc_ref.set(
+                {
+                    "roles": merged_roles,
+                    "updatedAt": firestore.SERVER_TIMESTAMP,
+                },
+                merge=True,
+            )
+
+            return https_fn.Response(
+                f"Custom claims updated successfully for user {id}: {merged_roles} and saved to Firestore",
+                status=200,
+            )
+        except Exception as firestore_error:
+            auth.set_custom_user_claims(id, current_claims)
+
+            return https_fn.Response(
+                f"Firestore update failed. Custom claims rolled back. Error: {str(firestore_error)}",
+                status=500,
+            )
+
+    except Exception as e:
+        return https_fn.Response(
+            f"Error processing the request: {str(e)}",
+            status=500,
+        )

--- a/kit/app_initial/lib/src/datasources/user/user_firebase_datasource.dart
+++ b/kit/app_initial/lib/src/datasources/user/user_firebase_datasource.dart
@@ -66,6 +66,7 @@ class UserFirebaseDatasource implements UserDatasource {
       'lastName': lastName,
       'email': email,
       'photo': photo,
+      'roles': <String, bool>{},
       'updatedAt': FieldValue.serverTimestamp(),
       'createdAt': FieldValue.serverTimestamp(),
     });

--- a/kit/app_initial/lib/src/enums/enums.dart
+++ b/kit/app_initial/lib/src/enums/enums.dart
@@ -1,2 +1,3 @@
 export 'auth_provider.dart';
 export 'platform_type.dart';
+export 'user_role.dart';

--- a/kit/app_initial/lib/src/enums/user_role.dart
+++ b/kit/app_initial/lib/src/enums/user_role.dart
@@ -1,0 +1,24 @@
+enum UserRole {
+  admin,
+  viewer;
+
+  String get value {
+    switch (this) {
+      case UserRole.admin:
+        return 'admin';
+      case UserRole.viewer:
+        return 'viewer';
+    }
+  }
+
+  static UserRole fromString(String value) {
+    switch (value) {
+      case 'admin':
+        return UserRole.admin;
+      case 'viewer':
+        return UserRole.viewer;
+      default:
+        throw Exception('Unknown user role: $value');
+    }
+  }
+}

--- a/kit/app_initial/lib/src/mappers/user_mapper.dart
+++ b/kit/app_initial/lib/src/mappers/user_mapper.dart
@@ -1,3 +1,4 @@
+import 'package:app_initial/src/enums/enums.dart';
 import 'package:app_initial/src/models/user.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -10,6 +11,12 @@ class UserMapper {
       lastName: data['lastName'] as String,
       email: data['email'] as String,
       photo: data['photo'] as String?,
+      roles: (data['roles'] as Map<String, dynamic>)
+          .entries
+          .where((e) => e.value as bool)
+          .where((e) => UserRole.values.map((e) => e.value).contains(e.key))
+          .map((e) => UserRole.fromString(e.key))
+          .toList(),
       updatedAt: (data['updatedAt'] as Timestamp).toDate(),
       createdAt: (data['createdAt'] as Timestamp).toDate(),
     );

--- a/kit/app_initial/lib/src/models/user.dart
+++ b/kit/app_initial/lib/src/models/user.dart
@@ -1,3 +1,4 @@
+import 'package:app_initial/src/enums/enums.dart';
 import 'package:equatable/equatable.dart';
 
 class User extends Equatable {
@@ -7,6 +8,7 @@ class User extends Equatable {
     required this.lastName,
     required this.email,
     required this.photo,
+    required this.roles,
     required this.updatedAt,
     required this.createdAt,
   });
@@ -17,6 +19,7 @@ class User extends Equatable {
     this.lastName = '',
     this.email = '',
     this.photo = '',
+    this.roles = const [],
     DateTime? updatedAt,
     DateTime? createdAt,
   })  : updatedAt = updatedAt ?? DateTime.now(),
@@ -27,6 +30,7 @@ class User extends Equatable {
   final String lastName;
   final String email;
   final String? photo;
+  final List<UserRole> roles;
   final DateTime updatedAt;
   final DateTime createdAt;
 
@@ -42,6 +46,7 @@ class User extends Equatable {
     String? lastName,
     String? email,
     String? photo,
+    List<UserRole>? roles,
     DateTime? updatedAt,
     DateTime? createdAt,
   }) {
@@ -51,6 +56,7 @@ class User extends Equatable {
       lastName: lastName ?? this.lastName,
       email: email ?? this.email,
       photo: photo ?? this.photo,
+      roles: roles ?? this.roles,
       updatedAt: updatedAt ?? this.updatedAt,
       createdAt: createdAt ?? this.createdAt,
     );
@@ -63,6 +69,7 @@ class User extends Equatable {
         lastName,
         email,
         photo,
+        roles,
         updatedAt,
         createdAt,
       ];


### PR DESCRIPTION
Depends on #8

## Description

### Feature

This feature was created to set roles to the user, the roles are set in two places, Firestore (Database) and Auth (Claims). The function who is in charge of set the roles are in Cloud Functions and its name is set_user_roles. If some error happen in this functions that automatic do a rollback to keep the reference. The roles are set in Claims to use it with the Rules, check the [documentation](https://firebase.google.com/docs/auth/admin/custom-claims#python) to know more.

The implementation of who set the roles depends on the business logic of each project. There are projects where users are allow to set or another where it's only possible set roles form an admin dashboard.

### How to use?

This request set the roles

Clarification: it isn't possible to see the claims in Firestore Auth, but it's possible in the emulators. 

Emulator

```
curl -X POST http://127.0.0.1:5001/<project-name>/<region>/set_user_roles \
-H "Content-Type: application/json" \
-d '{
    "id": "<user-id>",
    "roles": {"admin": true}
}'
```

Firebase

```
curl -X https://<region>-<project-name>.cloudfunctions.net/<project-name>/<region>/set_user_roles \
-H "Content-Type: application/json" \
-d '{
    "id": "<user-id>",
    "roles": {"admin": true}
}'
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
